### PR TITLE
feature: Implemented option for setting a custom panic handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -64,6 +64,7 @@ type WireError struct {
 	RequestUUID string
 }
 
+// PanicHandler is the type for custom functions for handling panics
 type PanicHandler func(context.Context, *HandlerError)
 
 // The HandlerFunc type is an adapter to allow the use of

--- a/handler.go
+++ b/handler.go
@@ -64,7 +64,7 @@ type WireError struct {
 	RequestUUID string
 }
 
-// PanicHandler is the type for custom functions for handling panics
+// PanicHandler is the type for custom functions for handling panics.
 type PanicHandler func(context.Context, *HandlerError)
 
 // The HandlerFunc type is an adapter to allow the use of

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"io"
@@ -37,6 +38,8 @@ type Options struct {
 	// The RequestUUID is also available in the specified handler (in HandleFunc()) by using GetRequestUUID().
 	// If RequestUUIDFunc is nil the default request uuid func will be used.
 	RequestUUIDFunc func() string
+	// CustomPanicHandler it's called when a panic occurrs in the HTTP handler. It gets the request context value.
+	CustomPanicHandler func(context.Context)
 }
 
 // SetLogFunc sets the log function that will be called in case of error.
@@ -101,12 +104,17 @@ func (o *Options) SetRequestUUIDFunc(requestUUIDFunc func() string) error {
 	return nil
 }
 
+func (o *Options) SetCustomPanicHandler(f func(context.Context)) {
+	o.CustomPanicHandler = f
+}
+
 func defaultOptions() *Options {
 	return &Options{
 		LogFunc:             defaultLogFunc(),
 		Encoders:            defaultEncoders(),
 		FallbackEncoderFunc: defaultFallbackEncoder(),
 		RequestUUIDFunc:     defaultRequestUUID(),
+		CustomPanicHandler:  defaultCustomPanicHandler(),
 	}
 }
 
@@ -175,4 +183,8 @@ func defaultRequestUUID() func() string {
 	return func() string {
 		return uuid.New().String()
 	}
+}
+
+func defaultCustomPanicHandler() func(context.Context) {
+	return func(ctx context.Context) {}
 }

--- a/options.go
+++ b/options.go
@@ -105,7 +105,7 @@ func (o *Options) SetRequestUUIDFunc(requestUUIDFunc func() string) error {
 }
 
 // SetCustomPanicHandler sets a custom function that is going to be called
-// when panic occurs
+// when panic occurs.
 func (o *Options) SetCustomPanicHandler(f func(context.Context, *HandlerError)) {
 	o.CustomPanicHandler = f
 }

--- a/options.go
+++ b/options.go
@@ -39,7 +39,7 @@ type Options struct {
 	// If RequestUUIDFunc is nil the default request uuid func will be used.
 	RequestUUIDFunc func() string
 	// CustomPanicHandler it's called when a panic occurrs in the HTTP handler. It gets the request context value.
-	CustomPanicHandler func(context.Context)
+	CustomPanicHandler func(context.Context, *HandlerError)
 }
 
 // SetLogFunc sets the log function that will be called in case of error.
@@ -104,7 +104,7 @@ func (o *Options) SetRequestUUIDFunc(requestUUIDFunc func() string) error {
 	return nil
 }
 
-func (o *Options) SetCustomPanicHandler(f func(context.Context)) {
+func (o *Options) SetCustomPanicHandler(f func(context.Context, *HandlerError)) {
 	o.CustomPanicHandler = f
 }
 
@@ -185,6 +185,6 @@ func defaultRequestUUID() func() string {
 	}
 }
 
-func defaultCustomPanicHandler() func(context.Context) {
-	return func(ctx context.Context) {}
+func defaultCustomPanicHandler() func(context.Context, *HandlerError) {
+	return func(ctx context.Context, err *HandlerError) {}
 }

--- a/options.go
+++ b/options.go
@@ -39,7 +39,7 @@ type Options struct {
 	// If RequestUUIDFunc is nil the default request uuid func will be used.
 	RequestUUIDFunc func() string
 	// CustomPanicHandler it's called when a panic occurrs in the HTTP handler. It gets the request context value.
-	CustomPanicHandler func(context.Context, *HandlerError)
+	CustomPanicHandler PanicHandler
 }
 
 // SetLogFunc sets the log function that will be called in case of error.
@@ -185,6 +185,6 @@ func defaultRequestUUID() func() string {
 	}
 }
 
-func defaultCustomPanicHandler() func(context.Context, *HandlerError) {
+func defaultCustomPanicHandler() PanicHandler {
 	return func(ctx context.Context, err *HandlerError) {}
 }

--- a/options.go
+++ b/options.go
@@ -104,6 +104,8 @@ func (o *Options) SetRequestUUIDFunc(requestUUIDFunc func() string) error {
 	return nil
 }
 
+// SetCustomPanicHandler sets a custom function that is going to be called
+// when panic occurs
 func (o *Options) SetCustomPanicHandler(f func(context.Context, *HandlerError)) {
 	o.CustomPanicHandler = f
 }


### PR DESCRIPTION
## Description
Implements part of the solution to https://github.com/talon-one/talon-integration/issues/162

## Problem
talon-integration needs a panic handler that sends a message to sentry

## Solution
Allow setting a custom panic handler option when creating an instance of `Handler`, since panics are recovered in this package and not in talon-integration. 

## Notes
A `context.Context` value is used to send values from talon-integration through this package and having them again in the panic handler implemented there.

<!--
Bumping
Any commit message that includes #major, #minor, or #patch will trigger the respective version bump.
If two or more are present, the highest-ranking one will take precedence.
If no #major, #minor or #patch tag is contained in the commit messages, it will bump patch.
-->