### PR TITLE
feat: add the ability to use more complex errors (#2) #patch

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -43,9 +43,9 @@ type HandlerError struct {
 	// If not specified HandleFunc will use http.StatusInternalServerError.
 	StatusCode int
 	// PublicError is the error that will be visible to the client. Do not include sensitive information here.
-	PublicError error
+	PublicError interface{}
 	// InternalError is the error that will not be visible to the client.
-	InternalError error
+	InternalError interface{}
 	// ContentType specifies the Content-Type of this error. If not specified HandleFunc will use the clients Accept
 	// header. If specified the clients Accept header will be ignored.
 	ContentType string
@@ -56,7 +56,7 @@ type WireError struct {
 	// StatusCode is the http status code that was sent to the client.
 	StatusCode int
 	// Error is the error message that should be send to the client.
-	Error string
+	Error interface{}
 	// RequestUUID is the request uuid that should be send to the client.
 	RequestUUID string
 }
@@ -119,8 +119,13 @@ func (h *Handler) HandleFunc(handler func(w http.ResponseWriter, r *http.Request
 func (h *Handler) sendError(err *HandlerError, requestUUID string, w http.ResponseWriter, r *http.Request) {
 	errorToSend := &WireError{
 		StatusCode:  err.StatusCode,
-		Error:       err.PublicError.Error(),
+		Error:       err.PublicError,
 		RequestUUID: requestUUID,
+	}
+
+	// if the public error is an error type use the string representation of the error
+	if e, ok := err.PublicError.(error); ok {
+		errorToSend.Error = e.Error()
 	}
 
 	var f EncodeFunc

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package httphandler
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -15,7 +16,7 @@ import (
 )
 
 // LogFunc is the log function that will be called in case of error.
-type LogFunc func(handlerError, internalError, publicError error, statusCode int, requestUUID string)
+type LogFunc func(handlerError error, internalError, publicError interface{}, statusCode int, requestUUID string)
 
 // EncodeFunc is the encode function that will be called to encode the WireError in the desired format.
 type EncodeFunc func(http.ResponseWriter, *http.Request, *WireError) error
@@ -111,7 +112,7 @@ func defaultOptions() *Options {
 }
 
 func defaultLogFunc() LogFunc {
-	return func(handlerError, internalError, publicError error, statusCode int, requestUUID string) {
+	return func(handlerError error, internalError, publicError interface{}, statusCode int, requestUUID string) {
 		log.Printf("%v: internalError=%v, publicError=%v, statusCode=%d, requestUUID=%s",
 			handlerError,
 			internalError,
@@ -140,7 +141,7 @@ func defaultEncoders() map[string]EncodeFunc {
 			if _, err := io.WriteString(w, " Error</title></head><body><h1>"); err != nil {
 				return err
 			}
-			if _, err := io.WriteString(w, e.Error); err != nil {
+			if _, err := fmt.Fprintf(w, "%#v", e.Error); err != nil {
 				return err
 			}
 			if _, err := io.WriteString(w, "<hr>"); err != nil {


### PR DESCRIPTION
## Description

## Problem
Sometimes it is useful to add more details to an error than a simple string. (see the code @ `TestExtendedError` [here](https://github.com/talon-one/go-httphandler/pull/2/files#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cR490) as an example)

This pull request changes the parts that reduce the error information to strings.


## Solution
Change the logic to use objects as a response where needed.

## Notes
Test also the removal of a encoder after creation of the handler.


<!--
Bumping
Any commit message that includes #major, #minor, or #patch will trigger the respective version bump.
If two or more are present, the highest-ranking one will take precedence.
If no #major, #minor or #patch tag is contained in the commit messages, it will bump patch.
-->