### PR TITLE
chore: remove magic conversion & make clear the errors need to be marshaled

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/talon-one/go-httphandler"
 )
 
@@ -27,7 +26,7 @@ func main() {
 			// respond with the clients Accept header content type
 			return &httphandler.HandlerError{
 				StatusCode:    http.StatusBadRequest,
-				PublicError:   errors.New("only POST method is allowed"),
+				PublicError:   "only POST method is allowed",
 				InternalError: nil,
 				ContentType:   "",
 			}
@@ -37,19 +36,19 @@ func main() {
 			// return with internal server error if body is not available
 			// respond with the clients Accept header content type
 			return &httphandler.HandlerError{
-				InternalError: errors.New("body was nil"),
+				InternalError: "body was nil",
 			}
 		}
 		if _, err := ioutil.ReadAll(r.Body); err != nil {
 			return &httphandler.HandlerError{
-				InternalError: err,
+				InternalError: err.Error(),
 			}
 		}
 
 		w.WriteHeader(http.StatusOK)
 		if _, err := io.WriteString(w, "ok"); err != nil {
 			return &httphandler.HandlerError{
-				InternalError: err,
+				InternalError: err.Error(),
 			}
 		}
 		return nil

--- a/example/example.go
+++ b/example/example.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/talon-one/go-httphandler"
 )
 
@@ -16,7 +15,7 @@ func main() {
 			// respond with the clients Accept header content type
 			return &httphandler.HandlerError{
 				StatusCode:    http.StatusBadRequest,
-				PublicError:   errors.New("only POST method is allowed"),
+				PublicError:   "only POST method is allowed",
 				InternalError: nil,
 				ContentType:   "",
 			}
@@ -26,19 +25,19 @@ func main() {
 			// return with internal server error if body is not available
 			// respond with the clients Accept header content type
 			return &httphandler.HandlerError{
-				InternalError: errors.New("body was nil"),
+				InternalError: "body was nil",
 			}
 		}
 		if _, err := ioutil.ReadAll(r.Body); err != nil {
 			return &httphandler.HandlerError{
-				InternalError: err,
+				InternalError: err.Error(),
 			}
 		}
 
 		w.WriteHeader(http.StatusOK)
 		if _, err := io.WriteString(w, "ok"); err != nil {
 			return &httphandler.HandlerError{
-				InternalError: err,
+				InternalError: err.Error(),
 			}
 		}
 		return nil

--- a/handler.go
+++ b/handler.go
@@ -77,7 +77,7 @@ type PanicHandler func(context.Context, *HandlerError)
 // Handler that calls f.
 type HandlerFunc func(w http.ResponseWriter, r *http.Request) *HandlerError
 
-// ServeHTTP mimics the http.Handler interface, with the addition of the *HandlerError
+// ServeHTTP mimics the http.Handler interface, with the addition of the *HandlerError.
 type ServeHTTP interface {
 	ServeHTTP(http.ResponseWriter, *http.Request) *HandlerError
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -20,7 +20,7 @@ func TestHandler(t *testing.T) {
 		LogFunc: func(handlerError error, internalError, publicError interface{}, statusCode int, requestUUID string) {
 			require.EqualError(t, handlerError, "handler error")
 			require.Nil(t, internalError)
-			require.Equal(t, "bad request", publicError.(error).Error())
+			require.Equal(t, "bad request", publicError)
 			require.Equal(t, http.StatusBadRequest, statusCode)
 			require.Equal(t, "0123456789", requestUUID)
 		},
@@ -54,7 +54,7 @@ func TestHandler(t *testing.T) {
 		if r.Method != http.MethodPost {
 			return &httphandler.HandlerError{
 				StatusCode:  http.StatusBadRequest,
-				PublicError: errors.New("bad request"),
+				PublicError: "bad request",
 			}
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -64,7 +64,7 @@ func TestHandler(t *testing.T) {
 		if r.Method != http.MethodPost {
 			return &httphandler.HandlerError{
 				StatusCode:  http.StatusBadRequest,
-				PublicError: errors.New("bad request"),
+				PublicError: "bad request",
 				ContentType: "text/html",
 			}
 		}
@@ -75,7 +75,7 @@ func TestHandler(t *testing.T) {
 		if r.Method != http.MethodPost {
 			return &httphandler.HandlerError{
 				StatusCode:  http.StatusBadRequest,
-				PublicError: errors.New("bad request"),
+				PublicError: "bad request",
 				ContentType: "application/json",
 			}
 		}
@@ -177,7 +177,7 @@ func TestDefaultErrorValues(t *testing.T) {
 	require.NoError(t, h.SetLogFunc(func(handlerError error, internalError, publicError interface{}, statusCode int, requestUUID string) {
 		require.EqualError(t, handlerError, "handler error")
 		require.Nil(t, internalError)
-		require.Equal(t, "unknown error", publicError.(error).Error())
+		require.Equal(t, "unknown error", publicError)
 		require.Equal(t, http.StatusInternalServerError, statusCode)
 		require.Equal(t, "0123456789", requestUUID)
 	}))
@@ -364,7 +364,7 @@ func TestSetLogFuncAndSetRequestUUIDFuncOption(t *testing.T) {
 	require.NoError(t, h.SetLogFunc(func(handlerError error, internalError, publicError interface{}, statusCode int, requestUUID string) {
 		require.EqualError(t, handlerError, "handler error")
 		require.Nil(t, internalError)
-		require.Equal(t, "unknown error", publicError.(error).Error())
+		require.Equal(t, "unknown error", publicError)
 		require.Equal(t, http.StatusInternalServerError, statusCode)
 		require.Equal(t, "0123456789", requestUUID)
 	}))
@@ -523,7 +523,7 @@ func TestRemoveEncoder(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handler.HandleFunc(func(w http.ResponseWriter, r *http.Request) *httphandler.HandlerError {
 		return &httphandler.HandlerError{
-			PublicError: errors.New("unknown error"),
+			PublicError: "unknown error",
 		}
 	}))
 	s := httptest.NewServer(mux)

--- a/options.go
+++ b/options.go
@@ -39,7 +39,7 @@ type Options struct {
 	// The RequestUUID is also available in the specified handler (in HandleFunc()) by using GetRequestUUID().
 	// If RequestUUIDFunc is nil the default request uuid func will be used.
 	RequestUUIDFunc func() string
-	// CustomPanicHandler it's called when a panic occurrs in the HTTP handler. It gets the request context value.
+	// CustomPanicHandler it's called when a panic occurs in the HTTP handler. It gets the request context value.
 	CustomPanicHandler PanicHandler
 }
 
@@ -105,9 +105,8 @@ func (o *Options) SetRequestUUIDFunc(requestUUIDFunc func() string) error {
 	return nil
 }
 
-// SetCustomPanicHandler sets a custom function that is going to be called
-// when panic occurs.
-func (o *Options) SetCustomPanicHandler(f func(context.Context, *HandlerError)) {
+// SetCustomPanicHandler sets a custom function that is going to be called when a panic occurs.
+func (o *Options) SetCustomPanicHandler(f PanicHandler) {
 	o.CustomPanicHandler = f
 }
 


### PR DESCRIPTION
## Description

Since we can now can use other objects than errors, it must be clear that the object will be marshaled.
Also get rid of the magic call to `Error() string`.
